### PR TITLE
Fix transformer eval url

### DIFF
--- a/_data/transformer-evaluation.yml
+++ b/_data/transformer-evaluation.yml
@@ -100,7 +100,7 @@
     url: https://www.biorxiv.org/content/10.1101/2024.09.30.615843v1
   code:
     type: reproducible
-    text: "[ð\x9F\x9B\_ï¸\x8FGitHub](https://github.com/turbine-ai/PerturbSeqPredBenchmark"
+    text: "[ð\x9F\x9B\_ï¸\x8FGitHub](https://github.com/turbine-ai/PerturbSeqPredBenchmark)"
     url: https://github.com/turbine-ai/PerturbSeqPredBenchmark
   omic_modalities: scRNA-seq
   evaluated_transformers: scGPT


### PR DESCRIPTION
Hi, I messed up the code url in the recent merge https://github.com/theislab/single-cell-transformer-papers/pull/74. This PR adds the missing parenthesis. Sorry for the mistake, I didn't build the site to check if everything is fine. 
Thanks for your efforts!